### PR TITLE
Add UUID handling support

### DIFF
--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/ChartmakerHitPlayer.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/ChartmakerHitPlayer.cs
@@ -1,5 +1,6 @@
 using JANOARG.Shared.Data.ChartInfo;
 using JANOARG.Chartmaker.Utils;
+using Unity.Collections;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -17,6 +18,9 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         
         public Transform HitObjectPosition;
 
+        [SerializeField] [ReadOnly]
+        private ulong Uuid;
+
         public void OnDestroy()
         {
             if (HoldTail)
@@ -25,6 +29,9 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
 
         public void UpdateObjects(HitObjectManager hit) 
         {
+            if (CurrentHit != null && Uuid != CurrentHit.Uuid)
+                Uuid = CurrentHit.Uuid;
+            
             CurrentHit = hit;
             transform.localPosition = hit.Position;
             transform.localRotation = hit.Rotation;

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/ChartmakerLanePlayer.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/ChartmakerLanePlayer.cs
@@ -1,12 +1,14 @@
 using System.Collections.Generic;
 using JANOARG.Shared.Data.ChartInfo;
 using JANOARG.Chartmaker.Utils;
+using Unity.Collections;
 using UnityEngine;
 
 namespace JANOARG.Chartmaker.Behaviors.Chartmaker
 {
     public class ChartmakerLanePlayer : MonoBehaviour
     {
+        
         public LaneManager    CurrentLane;
         public Transform      Holder;
         public MeshRenderer   Renderer;
@@ -15,10 +17,16 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         public MeshRenderer   JudgeLine;
         public MeshRenderer[] JudgeEnds;
 
+        [SerializeField][ReadOnly]
+        private ulong Uuid;
+
         public List<ChartmakerHitPlayer> HitPlayers { get; private set; } = new();
 
         public void UpdateObjects(LaneManager lane) 
         {
+            if (CurrentLane != null && Uuid != CurrentLane.Uuid)
+                Uuid = CurrentLane.Uuid;
+            
             CurrentLane = lane;
         
             transform.SetLocalPositionAndRotation(lane.FinalPosition, lane.FinalRotation);

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
@@ -75,14 +75,11 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
 
         public bool IsMaximised
         {
-            get
-            {
-                return
-                    HierarchyPanel.main.IsCollapsed
-                    && InspectorPanel.main.IsCollapsed
-                    && TimelinePanel.main.TimelineHeight <= 0
-                ;
-            }
+            get =>
+                HierarchyPanel.main.IsCollapsed
+                && InspectorPanel.main.IsCollapsed
+                && TimelinePanel.main.TimelineHeight <= 0;
+
             set
             {
                 if (value)


### PR DESCRIPTION
A supposedly breaking change, as it also changes the chart file format

UUID is seeded through metadata with salts, bounded to uint32

This should allow more robust implementation and some hard bug fixes where object references across serialisation becomes fragile