### PR TITLE
Fix parity by deduplication protection

### DIFF
--- a/Assets/JANOARG.Chartmaker/Resources/Prefabs/Chartmaker/Lane Group.prefab
+++ b/Assets/JANOARG.Chartmaker/Resources/Prefabs/Chartmaker/Lane Group.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6564782433039596236
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2049652837511886631}
+  - component: {fileID: 4521886620476838328}
+  m_Layer: 0
+  m_Name: Lane Group
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2049652837511886631
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6564782433039596236}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4521886620476838328
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6564782433039596236}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d524261029180a6f9b266aaf028ba51f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/JANOARG.Chartmaker/Resources/Prefabs/Chartmaker/Lane Group.prefab.meta
+++ b/Assets/JANOARG.Chartmaker/Resources/Prefabs/Chartmaker/Lane Group.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0cc92be8a2f476cc1ae6aaad629fab7d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
@@ -435,20 +435,20 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         /// </summary>
         public static void DeduplicateGroupNames(Chart chart)
         {
-            // Track how many times each original name has been seen so far.
-            Dictionary<string, int> seen = new();
-            for (int a = 0; a < chart.Groups.Count; a++)
+            List<LaneGroup> groups = chart.Groups;
+            for (int i = 0; i < groups.Count;)
             {
-                string name = chart.Groups[a].Name;
-                if (seen.TryGetValue(name, out int count))
+                List<LaneGroup> duplicates = groups.FindAll(x => x.Name == groups[i].Name);
+                int count = duplicates.Count;
+
+                if (count > 1)
                 {
-                    chart.Groups[a].Name = $"{name} ({count + 1})";
-                    seen[name] = count + 1;
+                    int n = 0;
+                    foreach (LaneGroup laneGroup in duplicates)
+                        laneGroup.Name = n++ != 0 ? $"{laneGroup.Name} ({n})" : laneGroup.Name;
                 }
-                else
-                {
-                    seen[name] = 1;
-                }
+
+                i += count;
             }
         }
 

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
@@ -435,13 +435,20 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         /// </summary>
         public static void DeduplicateGroupNames(Chart chart)
         {
+            // Track how many times each original name has been seen so far.
+            Dictionary<string, int> seen = new();
             for (int a = 0; a < chart.Groups.Count; a++)
             {
-                int priorCount = 0;
-                for (int b = 0; b < a; b++)
-                    if (chart.Groups[b].Name == chart.Groups[a].Name) priorCount++;
-                if (priorCount > 0)
-                    chart.Groups[a].Name = $"{chart.Groups[a].Name} ({priorCount + 1})";
+                string name = chart.Groups[a].Name;
+                if (seen.TryGetValue(name, out int count))
+                {
+                    chart.Groups[a].Name = $"{name} ({count + 1})";
+                    seen[name] = count + 1;
+                }
+                else
+                {
+                    seen[name] = 1;
+                }
             }
         }
 

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
@@ -698,16 +698,15 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
             // and fold the dedup renames into the same undo entry as a composite.
             if (action is ChartmakerAddAction addAction)
             {
-                List<ChartmakerGroupRenameAction> dedupeRenames = BuildGroupDedupeRenames(addAction);
+                List<IChartmakerAction> dedupeRenames = BuildDedupeRenames(addAction);
                 if (dedupeRenames.Count > 0)
                 {
                     ChartmakerCompositeAction composite = new()
                     {
                         Name = addAction.GetName(),
-                        // Add action already ran via Redo() above; wrap it so composite Undo works.
                         Actions = { addAction },
                     };
-                    foreach (ChartmakerGroupRenameAction rename in dedupeRenames)
+                    foreach (IChartmakerAction rename in dedupeRenames)
                     {
                         rename.Redo();
                         composite.Actions.Add(rename);
@@ -724,9 +723,9 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
             OnHistoryUpdate();
         }
 
-        private List<ChartmakerGroupRenameAction> BuildGroupDedupeRenames(ChartmakerAddAction addAction)
+        private List<IChartmakerAction> BuildDedupeRenames(ChartmakerAddAction addAction)
         {
-            List<ChartmakerGroupRenameAction> renames = new();
+            List<IChartmakerAction> renames = new();
 
             IEnumerable<object> added = addAction.Item is System.Collections.IList list
                 ? list.Cast<object>()
@@ -734,10 +733,30 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
 
             foreach (object item in added)
             {
-                if (item is not LaneGroup group) continue;
-                string newName = InspectorPanel.main.GetNewGroupName(group.Name, group);
-                if (newName == group.Name) continue;
-                renames.Add(new ChartmakerGroupRenameAction { From = group.Name, To = newName });
+                switch (item)
+                {
+                    case LaneGroup group:
+                    {
+                        string newName = InspectorPanel.main.GetNewGroupName(group.Name, group);
+                        if (newName != group.Name)
+                            renames.Add(new ChartmakerGroupRenameAction { From = group.Name, To = newName });
+                        break;
+                    }
+                    case LaneStyle laneStyle:
+                    {
+                        string newName = InspectorPanel.main.GetNewLaneStyleName(laneStyle.Name, laneStyle);
+                        if (newName != laneStyle.Name)
+                            renames.Add(new ChartmakerModifyAction { Item = laneStyle, Keyword = "Name", From = laneStyle.Name, To = newName });
+                        break;
+                    }
+                    case HitStyle hitStyle:
+                    {
+                        string newName = InspectorPanel.main.GetNewHitStyleName(hitStyle.Name, hitStyle);
+                        if (newName != hitStyle.Name)
+                            renames.Add(new ChartmakerModifyAction { Item = hitStyle, Keyword = "Name", From = hitStyle.Name, To = newName });
+                        break;
+                    }
+                }
             }
 
             return renames;

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
@@ -436,19 +436,14 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         public static void DeduplicateGroupNames(Chart chart)
         {
             List<LaneGroup> groups = chart.Groups;
-            for (int i = 0; i < groups.Count;)
+            for (int i = 0; i < groups.Count; i++)
             {
                 List<LaneGroup> duplicates = groups.FindAll(x => x.Name == groups[i].Name);
-                int count = duplicates.Count;
+                if (duplicates.Count < 2) continue;
 
-                if (count > 1)
-                {
-                    int n = 0;
-                    foreach (LaneGroup laneGroup in duplicates)
-                        laneGroup.Name = n++ != 0 ? $"{laneGroup.Name} ({n})" : laneGroup.Name;
-                }
-
-                i += count;
+                int n = 0;
+                foreach (LaneGroup laneGroup in duplicates)
+                    laneGroup.Name = n++ != 0 ? $"{laneGroup.Name} ({n})" : laneGroup.Name;
             }
         }
 

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -692,9 +693,54 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         public void DoAction(IChartmakerAction action)
         {
             action.Redo();
+
+            // After a successful add, check if any added LaneGroups have colliding names
+            // and fold the dedup renames into the same undo entry as a composite.
+            if (action is ChartmakerAddAction addAction)
+            {
+                List<ChartmakerGroupRenameAction> dedupeRenames = BuildGroupDedupeRenames(addAction);
+                if (dedupeRenames.Count > 0)
+                {
+                    ChartmakerCompositeAction composite = new()
+                    {
+                        Name = addAction.GetName(),
+                        // Add action already ran via Redo() above; wrap it so composite Undo works.
+                        Actions = { addAction },
+                    };
+                    foreach (ChartmakerGroupRenameAction rename in dedupeRenames)
+                    {
+                        rename.Redo();
+                        composite.Actions.Add(rename);
+                    }
+                    History.AddAction(composite);
+                    OnHistoryDo();
+                    OnHistoryUpdate();
+                    return;
+                }
+            }
+
             History.AddAction(action);
             OnHistoryDo();
             OnHistoryUpdate();
+        }
+
+        private List<ChartmakerGroupRenameAction> BuildGroupDedupeRenames(ChartmakerAddAction addAction)
+        {
+            List<ChartmakerGroupRenameAction> renames = new();
+
+            IEnumerable<object> added = addAction.Item is System.Collections.IList list
+                ? list.Cast<object>()
+                : new[] { addAction.Item };
+
+            foreach (object item in added)
+            {
+                if (item is not LaneGroup group) continue;
+                string newName = InspectorPanel.main.GetNewGroupName(group.Name, group);
+                if (newName == group.Name) continue;
+                renames.Add(new ChartmakerGroupRenameAction { From = group.Name, To = newName });
+            }
+
+            return renames;
         }
 
         public void SetItem(object target, string field, object value)

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/Chartmaker.cs
@@ -425,6 +425,24 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
             CurrentChart = JACDecoder.Decode(File.ReadAllText(path));
             CurrentChartPath = path;
             CurrentChartMeta = chart;
+            DeduplicateGroupNames(CurrentChart);
+        }
+
+        /// <summary>
+        /// Appends (n) suffixes to duplicate LaneGroup names in-place, so that saving
+        /// the file produces unique names. Charters can salvage a broken chart by loading
+        /// it in this version and saving again.
+        /// </summary>
+        public static void DeduplicateGroupNames(Chart chart)
+        {
+            for (int a = 0; a < chart.Groups.Count; a++)
+            {
+                int priorCount = 0;
+                for (int b = 0; b < a; b++)
+                    if (chart.Groups[b].Name == chart.Groups[a].Name) priorCount++;
+                if (priorCount > 0)
+                    chart.Groups[a].Name = $"{chart.Groups[a].Name} ({priorCount + 1})";
+            }
         }
 
         public Task OpenChartAsync(ExternalChartMeta chart)

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/ChartmakerLaneGroupPlayer.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/ChartmakerLaneGroupPlayer.cs
@@ -1,0 +1,23 @@
+using JANOARG.Shared.Data.ChartInfo;
+using UnityEngine;
+
+namespace JANOARG.Chartmaker.Behaviors.Chartmaker
+{
+    public class ChartmakerLaneGroupPlayer : MonoBehaviour
+    {
+        public LaneGroupManager CurrentGroup;
+
+        public void UpdateObjects(LaneGroupManager group)
+        {
+            CurrentGroup = group;
+
+            // Apply only this group's own local transform — nesting is handled
+            // by the GameObject hierarchy itself, so we must NOT use FinalPosition/FinalRotation
+            // (those have the parent chain baked in already).
+            transform.SetLocalPositionAndRotation(
+                group.CurrentGroup.Position,
+                Quaternion.Euler(group.CurrentGroup.Rotation)
+            );
+        }
+    }
+}

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/ChartmakerLaneGroupPlayer.cs.meta
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/ChartmakerLaneGroupPlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d524261029180a6f9b266aaf028ba51f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/ChartmakerLanePlayer.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/ChartmakerLanePlayer.cs
@@ -21,7 +21,12 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         {
             CurrentLane = lane;
         
-            transform.SetLocalPositionAndRotation(lane.FinalPosition, lane.FinalRotation);
+            // Use the lane's own Position/Rotation, not FinalPosition/FinalRotation.
+            // The group's transform is now applied by the parent ChartmakerLaneGroupPlayer GO.
+            transform.SetLocalPositionAndRotation(
+                lane.Current.Position,
+                Quaternion.Euler(lane.Current.Rotation)
+            );
         
             Holder.localPosition = Vector3.back * lane.CurrentDistance;
         

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/HierarchyPanel.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/HierarchyPanel.cs
@@ -49,7 +49,7 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         public Image  SearchIcon;
         public Image  SearchClearIcon;
 
-        Dictionary<string, HierarchyItem> GroupItems = new();
+        List<HierarchyItem> GroupItems = new();
 
         public void Awake()
         {
@@ -211,33 +211,45 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                         HierarchyItem worldItem = Items[0].Children[2];
                         worldItem.Children.Clear();
 
-                        // Add lane groups
-                        Dictionary<string, HierarchyItem> newGroupItems = new ();
-                        foreach (LaneGroup group in chart.Groups)
+                        // Add lane groups — parallel list matching chart.Groups indices.
+                        // Duplicates get their own HierarchyItems with (n) suffix, same as PlayerView.
+                        List<HierarchyItem> newGroupItems = new();
+                        for (int gi = 0; gi < chart.Groups.Count; gi++)
                         {
-                            HierarchyItem item = new () 
+                            LaneGroup group = chart.Groups[gi];
+
+                            // Names are already deduplicated in-place by PlayerView on load,
+                            // so group.Name is safe to use directly as the display name.
+                            bool expanded = gi < GroupItems.Count ? GroupItems[gi].Expanded : false;
+
+                            newGroupItems.Add(new HierarchyItem
                             {
                                 Name = group.Name,
                                 Type = HierarchyItemType.LaneGroup,
                                 Target = group,
-                                Expanded = GroupItems.ContainsKey(group.Name) ? GroupItems[group.Name].Expanded : false,
-                            };
-                            newGroupItems[group.Name] = item;
+                                Expanded = expanded,
+                            });
                         }
-                    
+
                         GroupItems = newGroupItems;
-                        Dictionary<string, HierarchyItem>.KeyCollection keys = GroupItems.Keys;
-                        int keyindex = 0;
-                    
-                        foreach (string key in keys)
+
+                        // Resolve parent hierarchy using first-match by name, same as client.
+                        for (int gi = 0; gi < chart.Groups.Count; gi++)
                         {
-                            LaneGroup data = (LaneGroup)GroupItems[key].Target;
-                            if (!string.IsNullOrEmpty(data.Group) && GroupItems.ContainsKey(data.Group)) GroupItems[data.Group].Children.Add(GroupItems[key]);
-                            else worldItem.Children.Add(GroupItems[key]);
-                            keyindex++;
+                            LaneGroup data = chart.Groups[gi];
+                            if (!string.IsNullOrEmpty(data.Group))
+                            {
+                                int parentIdx = chart.Groups.FindIndex(g => g.Name == data.Group);
+                                if (parentIdx >= 0)
+                                {
+                                    GroupItems[parentIdx].Children.Add(GroupItems[gi]);
+                                    continue;
+                                }
+                            }
+                            worldItem.Children.Add(GroupItems[gi]);
                         }
-                    
-                        // Add lanes
+
+                        // Add lanes — first-match by group name, same as client.
                         foreach (Lane lane in chart.Lanes)
                         {
                             HierarchyItem item = new () {
@@ -247,9 +259,10 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                                 Target = lane,
                             };
 
-                            if (!string.IsNullOrEmpty(lane.Group) && GroupItems.ContainsKey(lane.Group))
-                                GroupItems[lane.Group].Children.Add(item);
-                            else 
+                            int groupIdx = string.IsNullOrEmpty(lane.Group) ? -1 : chart.Groups.FindIndex(g => g.Name == lane.Group);
+                            if (groupIdx >= 0)
+                                GroupItems[groupIdx].Children.Add(item);
+                            else
                                 worldItem.Children.Add(item);
                         }
                     }

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/InspectorPanel.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/InspectorPanel.cs
@@ -1027,7 +1027,11 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
             ), (RectTransform)ExtraModesButton.transform, ContextMenuDirection.Left); 
         }
 
-        public string GetNewGroupName(string name, LaneGroup exclude = null) 
+        /// <summary>
+        /// Returns a unique name by incrementing a numeric suffix until
+        /// <paramref name="nameExists"/> returns false for the candidate.
+        /// </summary>
+        public static string GetNewUniqueName(string name, Func<string, bool> nameExists)
         {
             int index = 0;
             name = name.Trim();
@@ -1038,14 +1042,27 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                 index = int.Parse(match.Groups[2].Value);
             }
 
-            string newName() => index > 0 ? name + " " + index : name;
-
-            int foundIndex = 0;
-            while (
-                (foundIndex = Chartmaker.main.CurrentChart.Groups.FindIndex(x => x.Name == newName())) >= 0
-                && (foundIndex < 0 || Chartmaker.main.CurrentChart.Groups[foundIndex] != exclude)
-            ) index++;
+            string newName() => index > 0 ? $"{name} {index}" : name;
+            while (nameExists(newName())) index++;
             return newName();
+        }
+
+        public string GetNewGroupName(string name, LaneGroup exclude = null)
+        {
+            return GetNewUniqueName(name, candidate =>
+                Chartmaker.main.CurrentChart.Groups.Any(x => x != exclude && x.Name == candidate));
+        }
+
+        public string GetNewLaneStyleName(string name, LaneStyle exclude = null)
+        {
+            return GetNewUniqueName(name, candidate =>
+                Chartmaker.main.CurrentChart.Palette.LaneStyles.Any(x => x != exclude && x.Name == candidate));
+        }
+
+        public string GetNewHitStyleName(string name, HitStyle exclude = null)
+        {
+            return GetNewUniqueName(name, candidate =>
+                Chartmaker.main.CurrentChart.Palette.HitStyles.Any(x => x != exclude && x.Name == candidate));
         }
     
 

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
@@ -44,7 +44,7 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         public Transform Holder;
         public ChartmakerLaneGroupPlayer LaneGroupPlayerSample;
         public ChartmakerLanePlayer LanePlayerSample;
-        public List<ChartmakerLaneGroupPlayer> LaneGroupPlayers { get; private set; } = new();
+        public Dictionary<string, ChartmakerLaneGroupPlayer> LaneGroupPlayers { get; private set; } = new();
         public List<ChartmakerLanePlayer> LanePlayers { get; private set; } = new();
         public ChartmakerHitPlayer HitPlayerSample;
         public MeshRenderer        HoldMeshSample;
@@ -233,58 +233,54 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                 RenderSettings.fogColor = MainCamera.backgroundColor = Manager.PalleteManager.CurrentPallete.BackgroundColor;
                 BoundingBox.color = NotificationText.color = NotificationBox.color = Manager.PalleteManager.CurrentPallete.InterfaceColor;
 
-                // Pass 1: sync group player list to CurrentChart.Groups (parallel by index,
-                // matching client behaviour — duplicates get their own GOs).
-                var chart = Chartmaker.main.CurrentChart;
-                while (LaneGroupPlayers.Count > chart.Groups.Count)
+                // Pass 1: sync group player dict to Manager.Groups (post-ChartManager.Update,
+                // so duplicates in chart.Groups are already collapsed by the Dictionary).
+                foreach (var pair in LaneGroupPlayers)
+                    pair.Value.CurrentGroup = null;
+
+                foreach (var pair in Manager.Groups)
                 {
-                    Destroy(LaneGroupPlayers[^1].gameObject);
-                    LaneGroupPlayers.RemoveAt(LaneGroupPlayers.Count - 1);
-                }
-                while (LaneGroupPlayers.Count < chart.Groups.Count)
-                {
-                    int a = LaneGroupPlayers.Count;
-                    LaneGroupPlayers.Add(Instantiate(LaneGroupPlayerSample, Holder));
-                    #if UNITY_EDITOR
-                    // Names are already deduplicated by Chartmaker.DeduplicateGroupNames at load time.
-                    LaneGroupPlayers[a].gameObject.name = $"Lane Group ({chart.Groups[a].Name})";
-                    #endif
+                    string groupName = pair.Key;
+                    if (!LaneGroupPlayers.TryGetValue(groupName, out ChartmakerLaneGroupPlayer groupPlayer))
+                    {
+                        groupPlayer = Instantiate(LaneGroupPlayerSample, Holder);
+                        #if UNITY_EDITOR
+                        groupPlayer.gameObject.name = $"Lane Group ({groupName})";
+                        #endif
+                        LaneGroupPlayers[groupName] = groupPlayer;
+                    }
+                    groupPlayer.CurrentGroup = pair.Value;
                 }
 
-                for (int a = 0; a < chart.Groups.Count; a++)
-                {
-                    LaneGroup groupData = chart.Groups[a];
-                    // Look up the matching LaneGroupManager by name (first match, same as client).
-                    Manager.Groups.TryGetValue(groupData.Name, out LaneGroupManager groupManager);
-                    LaneGroupPlayers[a].CurrentGroup = groupManager;
-                }
+                // Destroy group players no longer in Manager.Groups.
+                var toRemove = new System.Collections.Generic.List<string>();
+                foreach (var pair in LaneGroupPlayers)
+                    if (pair.Value.CurrentGroup == null) { Destroy(pair.Value.gameObject); toRemove.Add(pair.Key); }
+                foreach (string key in toRemove) LaneGroupPlayers.Remove(key);
 
                 // Pass 2: resolve GO parent hierarchy BEFORE applying any local transforms.
-                // Use first-match by name for parent lookup, same as client.
-                for (int a = 0; a < chart.Groups.Count; a++)
+                foreach (var pair in LaneGroupPlayers)
                 {
-                    string parentGroupName = chart.Groups[a].Group;
-                    Transform desiredParent = !string.IsNullOrEmpty(parentGroupName)
-                        ? (LaneGroupPlayers.Find(x => x.CurrentGroup?.CurrentGroup.Name == parentGroupName)?.transform ?? Holder)
+                    string parentGroupName = pair.Value.CurrentGroup.CurrentGroup.Group;
+                    Transform desiredParent = !string.IsNullOrEmpty(parentGroupName) && LaneGroupPlayers.TryGetValue(parentGroupName, out ChartmakerLaneGroupPlayer parentPlayer)
+                        ? parentPlayer.transform
                         : Holder;
-                    if (LaneGroupPlayers[a].transform.parent != desiredParent)
-                        LaneGroupPlayers[a].transform.SetParent(desiredParent, worldPositionStays: false);
+                    if (pair.Value.transform.parent != desiredParent)
+                        pair.Value.transform.SetParent(desiredParent, worldPositionStays: false);
                 }
 
                 // Pass 3: apply local transforms — hierarchy is now correct.
-                for (int a = 0; a < chart.Groups.Count; a++)
-                    if (LaneGroupPlayers[a].CurrentGroup != null)
-                        LaneGroupPlayers[a].UpdateObjects(LaneGroupPlayers[a].CurrentGroup);
+                foreach (var pair in LaneGroupPlayers)
+                    pair.Value.UpdateObjects(pair.Value.CurrentGroup);
 
                 // Update lane players, parenting each under its group player (or Holder if ungrouped).
-                // First-match by name, same as client.
                 for (int a = 0; a < Manager.Lanes.Count; a++)
                 {
                     LaneManager laneManager = Manager.Lanes[a];
                     string laneGroupName = laneManager.Current.Group;
 
                     Transform desiredParent = !string.IsNullOrEmpty(laneGroupName)
-                        ? (LaneGroupPlayers.Find(x => x.CurrentGroup?.CurrentGroup.Name == laneGroupName)?.transform ?? Holder)
+                        ? (LaneGroupPlayers.TryGetValue(laneGroupName, out ChartmakerLaneGroupPlayer laneGroupPlayer) ? laneGroupPlayer.transform : Holder)
                         : Holder;
 
                     if (LanePlayers.Count <= a)
@@ -1098,8 +1094,8 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                 Destroy(lane.gameObject);
             }
             LanePlayers.Clear();
-            foreach (var groupPlayer in LaneGroupPlayers)
-                Destroy(groupPlayer.gameObject);
+            foreach (var pair in LaneGroupPlayers)
+                Destroy(pair.Value.gameObject);
             LaneGroupPlayers.Clear();
         }
 

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using JANOARG.Chartmaker.Data.Chartmaker;
 using JANOARG.Chartmaker.Data.Chartmaker.Actions;
 using JANOARG.Chartmaker.UI.Cursor;
@@ -241,7 +242,14 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                     LaneGroupPlayers.RemoveAt(LaneGroupPlayers.Count - 1);
                 }
                 while (LaneGroupPlayers.Count < chart.Groups.Count)
-                    LaneGroupPlayers.Add(Instantiate(LaneGroupPlayerSample, Holder));
+                {
+                    ChartmakerLaneGroupPlayer laneGroup = Instantiate(LaneGroupPlayerSample, Holder);
+                    int n = 0;
+                    
+                    while (laneGroup.name == null && LaneGroupPlayers.Any(x => x.CurrentGroup?.CurrentGroup.Name == laneGroup.CurrentGroup?.CurrentGroup.Name))
+                        laneGroup.name = laneGroup.CurrentGroup.CurrentGroup.Name = $"{laneGroup.name} ({n++})";
+                    LaneGroupPlayers.Add(laneGroup);
+                }
 
                 for (int a = 0; a < chart.Groups.Count; a++)
                 {

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
@@ -43,7 +43,7 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         public Transform Holder;
         public ChartmakerLaneGroupPlayer LaneGroupPlayerSample;
         public ChartmakerLanePlayer LanePlayerSample;
-        public Dictionary<string, ChartmakerLaneGroupPlayer> LaneGroupPlayers { get; private set; } = new();
+        public List<ChartmakerLaneGroupPlayer> LaneGroupPlayers { get; private set; } = new();
         public List<ChartmakerLanePlayer> LanePlayers { get; private set; } = new();
         public ChartmakerHitPlayer HitPlayerSample;
         public MeshRenderer        HoldMeshSample;
@@ -232,85 +232,71 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                 RenderSettings.fogColor = MainCamera.backgroundColor = Manager.PalleteManager.CurrentPallete.BackgroundColor;
                 BoundingBox.color = NotificationText.color = NotificationBox.color = Manager.PalleteManager.CurrentPallete.InterfaceColor;
 
-                // Update lane group GameObjects — one per named group, nested by their Group field.
-                // Mark all existing players untouched; we'll remove any that are no longer in the chart.
-                foreach (var pair in LaneGroupPlayers)
-                    pair.Value.CurrentGroup = null;
-
-                foreach (var pair in Manager.Groups)
+                // Pass 1: sync group player list to CurrentChart.Groups (parallel by index,
+                // matching client behaviour — duplicates get their own GOs).
+                var chart = Chartmaker.main.CurrentChart;
+                while (LaneGroupPlayers.Count > chart.Groups.Count)
                 {
-                    LaneGroupManager groupManager = pair.Value;
-                    string groupName = pair.Key;
+                    Destroy(LaneGroupPlayers[^1].gameObject);
+                    LaneGroupPlayers.RemoveAt(LaneGroupPlayers.Count - 1);
+                }
+                while (LaneGroupPlayers.Count < chart.Groups.Count)
+                    LaneGroupPlayers.Add(Instantiate(LaneGroupPlayerSample, Holder));
 
-                    if (!LaneGroupPlayers.TryGetValue(groupName, out ChartmakerLaneGroupPlayer groupPlayer))
-                    {
-                        groupPlayer = Instantiate(LaneGroupPlayerSample, Holder);
-                        
-                        #if UNITY_EDITOR
-                        if (!string.IsNullOrWhiteSpace(groupPlayer.gameObject.name)   
-                            && groupPlayer.gameObject.name != "Lane Group (Clone)"    
-                            && groupPlayer.gameObject.name != groupName)              
-                        {
-                            groupPlayer.gameObject.name = $"Lane Group ({groupName})";
-                        }
-                        #endif
-                        LaneGroupPlayers[groupName] = groupPlayer;
-                    }
+                for (int a = 0; a < chart.Groups.Count; a++)
+                {
+                    LaneGroup groupData = chart.Groups[a];
+                    // Look up the matching LaneGroupManager by name (first match, same as client).
+                    Manager.Groups.TryGetValue(groupData.Name, out LaneGroupManager groupManager);
+                    LaneGroupPlayers[a].CurrentGroup = groupManager;
 
-                    groupPlayer.UpdateObjects(groupManager);
+                    #if UNITY_EDITOR
+                    // Count how many times this name has appeared before index a to detect duplicates.
+                    int priorCount = 0;
+                    for (int b = 0; b < a; b++)
+                        if (chart.Groups[b].Name == groupData.Name) priorCount++;
+                    LaneGroupPlayers[a].gameObject.name = priorCount == 0
+                        ? $"Lane Group ({groupData.Name})"
+                        : $"Lane Group ({groupData.Name}) ({priorCount + 1})";
+                    #endif
                 }
 
-                // Destroy group players that are no longer in the chart
-                var toRemove = new System.Collections.Generic.List<string>();
-                foreach (var pair in LaneGroupPlayers)
+                // Pass 2: resolve GO parent hierarchy BEFORE applying any local transforms.
+                // Use first-match by name for parent lookup, same as client.
+                for (int a = 0; a < chart.Groups.Count; a++)
                 {
-                    if (pair.Value.CurrentGroup == null)
-                    {
-                        Destroy(pair.Value.gameObject);
-                        toRemove.Add(pair.Key);
-                    }
-                }
-                foreach (string key in toRemove)
-                    LaneGroupPlayers.Remove(key);
-
-                // Now nest group players under their parent group player (or Holder if no parent).
-                foreach (var pair in LaneGroupPlayers)
-                {
-                    LaneGroupManager groupManager = pair.Value.CurrentGroup;
-                    string parentGroupName = groupManager.CurrentGroup.Group;
-
-                    Transform desiredParent = !string.IsNullOrEmpty(parentGroupName) && LaneGroupPlayers.TryGetValue(parentGroupName, out ChartmakerLaneGroupPlayer parentPlayer)
-                        ? parentPlayer.transform
+                    string parentGroupName = chart.Groups[a].Group;
+                    Transform desiredParent = !string.IsNullOrEmpty(parentGroupName)
+                        ? (LaneGroupPlayers.Find(x => x.CurrentGroup?.CurrentGroup.Name == parentGroupName)?.transform ?? Holder)
                         : Holder;
-
-                    if (pair.Value.transform.parent != desiredParent)
-                        pair.Value.transform.SetParent(desiredParent, worldPositionStays: false);
+                    if (LaneGroupPlayers[a].transform.parent != desiredParent)
+                        LaneGroupPlayers[a].transform.SetParent(desiredParent, worldPositionStays: false);
                 }
+
+                // Pass 3: apply local transforms — hierarchy is now correct.
+                for (int a = 0; a < chart.Groups.Count; a++)
+                    if (LaneGroupPlayers[a].CurrentGroup != null)
+                        LaneGroupPlayers[a].UpdateObjects(LaneGroupPlayers[a].CurrentGroup);
 
                 // Update lane players, parenting each under its group player (or Holder if ungrouped).
+                // First-match by name, same as client.
                 for (int a = 0; a < Manager.Lanes.Count; a++)
                 {
                     LaneManager laneManager = Manager.Lanes[a];
                     string laneGroupName = laneManager.Current.Group;
 
-                    Transform desiredParent = !string.IsNullOrEmpty(laneGroupName) && LaneGroupPlayers.TryGetValue(laneGroupName, out ChartmakerLaneGroupPlayer groupPlayer)
-                        ? groupPlayer.transform
+                    Transform desiredParent = !string.IsNullOrEmpty(laneGroupName)
+                        ? (LaneGroupPlayers.Find(x => x.CurrentGroup?.CurrentGroup.Name == laneGroupName)?.transform ?? Holder)
                         : Holder;
 
-                    ChartmakerLanePlayer lane = Instantiate(LanePlayerSample, desiredParent);
-                    
-                    #if UNITY_EDITOR
-                    if (!string.IsNullOrWhiteSpace(lane.gameObject.name)   // Ensure the name exists and is not whitespace
-                        && lane.gameObject.name != laneManager.Current.Name
-                        && !string.IsNullOrEmpty(laneGroupName) 
-                        && !string.IsNullOrEmpty(laneManager.Current.Group))
-                    {
-                        lane.gameObject.name = lane.gameObject.name == "Lane(Clone)" ? $"Lane ({(BeatPosition)laneManager.Steps[0].Offset} > {(BeatPosition)laneManager.Steps[^1].Offset})" :laneManager.Current.Name;
-                    }
-                    #endif
-
                     if (LanePlayers.Count <= a)
-                        LanePlayers.Add(lane);
+                    {
+                        LanePlayers.Add(Instantiate(LanePlayerSample, desiredParent));
+                        #if UNITY_EDITOR
+                        string beatRange = $"Lane ({(BeatPosition)laneManager.Steps[0].Offset} > {(BeatPosition)laneManager.Steps[^1].Offset})";
+                        LanePlayers[a].gameObject.name = string.IsNullOrEmpty(laneManager.Current.Name) ? beatRange : laneManager.Current.Name;
+                        #endif
+                    }
                     else if (LanePlayers[a].transform.parent != desiredParent)
                         LanePlayers[a].transform.SetParent(desiredParent, worldPositionStays: false);
 
@@ -1114,8 +1100,8 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                 Destroy(lane.gameObject);
             }
             LanePlayers.Clear();
-            foreach (var pair in LaneGroupPlayers)
-                Destroy(pair.Value.gameObject);
+            foreach (var groupPlayer in LaneGroupPlayers)
+                Destroy(groupPlayer.gameObject);
             LaneGroupPlayers.Clear();
         }
 

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
@@ -41,7 +41,9 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         [Space]
         [Header("World")]
         public Transform Holder;
+        public ChartmakerLaneGroupPlayer LaneGroupPlayerSample;
         public ChartmakerLanePlayer LanePlayerSample;
+        public Dictionary<string, ChartmakerLaneGroupPlayer> LaneGroupPlayers { get; private set; } = new();
         public List<ChartmakerLanePlayer> LanePlayers { get; private set; } = new();
         public ChartmakerHitPlayer HitPlayerSample;
         public MeshRenderer        HoldMeshSample;
@@ -230,14 +232,76 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                 RenderSettings.fogColor = MainCamera.backgroundColor = Manager.PalleteManager.CurrentPallete.BackgroundColor;
                 BoundingBox.color = NotificationText.color = NotificationBox.color = Manager.PalleteManager.CurrentPallete.InterfaceColor;
 
+                // Update lane group GameObjects — one per named group, nested by their Group field.
+                // Mark all existing players untouched; we'll remove any that are no longer in the chart.
+                foreach (var pair in LaneGroupPlayers)
+                    pair.Value.CurrentGroup = null;
+
+                foreach (var pair in Manager.Groups)
+                {
+                    LaneGroupManager groupManager = pair.Value;
+                    string groupName = pair.Key;
+
+                    if (!LaneGroupPlayers.TryGetValue(groupName, out ChartmakerLaneGroupPlayer groupPlayer))
+                    {
+                        groupPlayer = Instantiate(LaneGroupPlayerSample, Holder);
+                        if (groupPlayer.gameObject.name != groupName && groupPlayer.gameObject.name != "Lane Group (Clone)")
+                            groupPlayer.gameObject.name = groupName;
+                        LaneGroupPlayers[groupName] = groupPlayer;
+                    }
+
+                    groupPlayer.UpdateObjects(groupManager);
+                }
+
+                // Destroy group players that are no longer in the chart
+                var toRemove = new System.Collections.Generic.List<string>();
+                foreach (var pair in LaneGroupPlayers)
+                {
+                    if (pair.Value.CurrentGroup == null)
+                    {
+                        Destroy(pair.Value.gameObject);
+                        toRemove.Add(pair.Key);
+                    }
+                }
+                foreach (string key in toRemove)
+                    LaneGroupPlayers.Remove(key);
+
+                // Now nest group players under their parent group player (or Holder if no parent).
+                foreach (var pair in LaneGroupPlayers)
+                {
+                    LaneGroupManager groupManager = pair.Value.CurrentGroup;
+                    string parentGroupName = groupManager.CurrentGroup.Group;
+
+                    Transform desiredParent = !string.IsNullOrEmpty(parentGroupName) && LaneGroupPlayers.TryGetValue(parentGroupName, out ChartmakerLaneGroupPlayer parentPlayer)
+                        ? parentPlayer.transform
+                        : Holder;
+
+                    if (pair.Value.transform.parent != desiredParent)
+                        pair.Value.transform.SetParent(desiredParent, worldPositionStays: false);
+                }
+
+                // Update lane players, parenting each under its group player (or Holder if ungrouped).
                 for (int a = 0; a < Manager.Lanes.Count; a++)
                 {
-                    if (LanePlayers.Count <= a) 
-                        LanePlayers.Add(Instantiate(LanePlayerSample, Holder));
-                
-                    LanePlayers[a].UpdateObjects(Manager.Lanes[a]);
+                    LaneManager laneManager = Manager.Lanes[a];
+                    string laneGroupName = laneManager.Current.Group;
+
+                    Transform desiredParent = !string.IsNullOrEmpty(laneGroupName) && LaneGroupPlayers.TryGetValue(laneGroupName, out ChartmakerLaneGroupPlayer groupPlayer)
+                        ? groupPlayer.transform
+                        : Holder;
+
+                    ChartmakerLanePlayer lane = Instantiate(LanePlayerSample, desiredParent);
+                    if (lane.gameObject.name != laneManager.Current.Name && lane.gameObject.name != "Lane (Clone)")
+                        lane.gameObject.name = laneManager.Current.Name;
+
+                    if (LanePlayers.Count <= a)
+                        LanePlayers.Add(lane);
+                    else if (LanePlayers[a].transform.parent != desiredParent)
+                        LanePlayers[a].transform.SetParent(desiredParent, worldPositionStays: false);
+
+                    LanePlayers[a].UpdateObjects(laneManager);
                 }
-            
+
                 while (LanePlayers.Count > Manager.Lanes.Count)
                 {
                     Destroy(LanePlayers[Manager.Lanes.Count].gameObject);
@@ -1035,6 +1099,9 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                 Destroy(lane.gameObject);
             }
             LanePlayers.Clear();
+            foreach (var pair in LaneGroupPlayers)
+                Destroy(pair.Value.gameObject);
+            LaneGroupPlayers.Clear();
         }
 
         public void UpdateIconFile() 

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
@@ -245,8 +245,15 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                     if (!LaneGroupPlayers.TryGetValue(groupName, out ChartmakerLaneGroupPlayer groupPlayer))
                     {
                         groupPlayer = Instantiate(LaneGroupPlayerSample, Holder);
-                        if (groupPlayer.gameObject.name != groupName && groupPlayer.gameObject.name != "Lane Group (Clone)")
-                            groupPlayer.gameObject.name = groupName;
+                        
+                        #if UNITY_EDITOR
+                        if (!string.IsNullOrWhiteSpace(groupPlayer.gameObject.name)   
+                            && groupPlayer.gameObject.name != "Lane Group (Clone)"    
+                            && groupPlayer.gameObject.name != groupName)              
+                        {
+                            groupPlayer.gameObject.name = $"Lane Group ({groupName})";
+                        }
+                        #endif
                         LaneGroupPlayers[groupName] = groupPlayer;
                     }
 
@@ -291,8 +298,16 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                         : Holder;
 
                     ChartmakerLanePlayer lane = Instantiate(LanePlayerSample, desiredParent);
-                    if (lane.gameObject.name != laneManager.Current.Name && lane.gameObject.name != "Lane (Clone)")
-                        lane.gameObject.name = laneManager.Current.Name;
+                    
+                    #if UNITY_EDITOR
+                    if (!string.IsNullOrWhiteSpace(lane.gameObject.name)   // Ensure the name exists and is not whitespace
+                        && lane.gameObject.name != laneManager.Current.Name
+                        && !string.IsNullOrEmpty(laneGroupName) 
+                        && !string.IsNullOrEmpty(laneManager.Current.Group))
+                    {
+                        lane.gameObject.name = lane.gameObject.name == "Lane(Clone)" ? $"Lane ({(BeatPosition)laneManager.Steps[0].Offset} > {(BeatPosition)laneManager.Steps[^1].Offset})" :laneManager.Current.Name;
+                    }
+                    #endif
 
                     if (LanePlayers.Count <= a)
                         LanePlayers.Add(lane);

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/PlayerView.cs
@@ -243,12 +243,12 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                 }
                 while (LaneGroupPlayers.Count < chart.Groups.Count)
                 {
-                    ChartmakerLaneGroupPlayer laneGroup = Instantiate(LaneGroupPlayerSample, Holder);
-                    int n = 0;
-                    
-                    while (laneGroup.name == null && LaneGroupPlayers.Any(x => x.CurrentGroup?.CurrentGroup.Name == laneGroup.CurrentGroup?.CurrentGroup.Name))
-                        laneGroup.name = laneGroup.CurrentGroup.CurrentGroup.Name = $"{laneGroup.name} ({n++})";
-                    LaneGroupPlayers.Add(laneGroup);
+                    int a = LaneGroupPlayers.Count;
+                    LaneGroupPlayers.Add(Instantiate(LaneGroupPlayerSample, Holder));
+                    #if UNITY_EDITOR
+                    // Names are already deduplicated by Chartmaker.DeduplicateGroupNames at load time.
+                    LaneGroupPlayers[a].gameObject.name = $"Lane Group ({chart.Groups[a].Name})";
+                    #endif
                 }
 
                 for (int a = 0; a < chart.Groups.Count; a++)
@@ -257,16 +257,6 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
                     // Look up the matching LaneGroupManager by name (first match, same as client).
                     Manager.Groups.TryGetValue(groupData.Name, out LaneGroupManager groupManager);
                     LaneGroupPlayers[a].CurrentGroup = groupManager;
-
-                    #if UNITY_EDITOR
-                    // Count how many times this name has appeared before index a to detect duplicates.
-                    int priorCount = 0;
-                    for (int b = 0; b < a; b++)
-                        if (chart.Groups[b].Name == groupData.Name) priorCount++;
-                    LaneGroupPlayers[a].gameObject.name = priorCount == 0
-                        ? $"Lane Group ({groupData.Name})"
-                        : $"Lane Group ({groupData.Name}) ({priorCount + 1})";
-                    #endif
                 }
 
                 // Pass 2: resolve GO parent hierarchy BEFORE applying any local transforms.

--- a/Assets/JANOARG.Chartmaker/Scripts/Data/Chartmaker/Actions/ChartmakerCompositeAction.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Data/Chartmaker/Actions/ChartmakerCompositeAction.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace JANOARG.Chartmaker.Data.Chartmaker.Actions
+{
+    /// <summary>
+    /// Wraps multiple actions into a single undo/redo entry.
+    /// Redo executes actions in forward order; Undo executes in reverse.
+    /// </summary>
+    public class ChartmakerCompositeAction : IChartmakerAction
+    {
+        public List<IChartmakerAction> Actions = new();
+        public string Name;
+
+        public string GetName() => Name ?? (Actions.Count > 0 ? Actions[0].GetName() : "Composite Action");
+
+        public void Redo()
+        {
+            foreach (IChartmakerAction action in Actions)
+                action.Redo();
+        }
+
+        public void Undo()
+        {
+            for (int i = Actions.Count - 1; i >= 0; i--)
+                Actions[i].Undo();
+        }
+    }
+}

--- a/Assets/JANOARG.Chartmaker/Scripts/Data/Chartmaker/Actions/ChartmakerCompositeAction.cs.meta
+++ b/Assets/JANOARG.Chartmaker/Scripts/Data/Chartmaker/Actions/ChartmakerCompositeAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3589e971c4c2cf50b92e8d72d4bd457
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Apparently most of the source of charts is being broken without an obvious trace is due to the differences in Chartmaker and Client when loading charts

In Chartmaker, duplicate lane groups are overwritten, usually getting the 'correct' one by chance. While Player, files them differently and creates multiple lane groups of the same name which made the lane loader confused.

This change should mitigate it by explicitly showing groups and styles that are duplicated by load-time suffix annotation, which allows charters to fix it swiftly instead of having to write the entire chart from scratch. Also happens during paste and renaming

And also Lane Groups are literally rendered as literal GameObjects instead of mathematically calculated.

Notably, the hit and lane style deduplication are unnecssary by functionality but it should help in charter's disambiguity.

This change also comes with `ChartmakerCompositeAction` which wraps multiple action into one undo/redo stack that deduplication protection uses to make sure charters can't shoot themselves in the foot with no possible practical advantage.